### PR TITLE
[VRR] Add vrr.de/VRR parser for Verkehrsverbund Rhein Ruhr

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -134,6 +134,7 @@ HEADERS += \
     src/parser/parser_salzburg_efa.h \
     src/parser/parser_resrobot.h \
     src/parser/parser_finland_matka.h \
+    src/parser/parser_vrr_efa.h \
     src/models/backends.h
 
 SOURCES += src/main.cpp \
@@ -169,6 +170,7 @@ SOURCES += src/main.cpp \
     src/parser/parser_salzburg_efa.cpp \
     src/parser/parser_resrobot.cpp \
     src/parser/parser_finland_matka.cpp \
+    src/parser/parser_vrr_efa.cpp \
     src/models/backends.cpp
 
 LIBS += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.cpp

--- a/src/fahrplan_backend_manager.cpp
+++ b/src/fahrplan_backend_manager.cpp
@@ -45,6 +45,7 @@ QStringList FahrplanBackendManager::getParserList()
     result.append(ParserSalzburgEFA::getName());
     result.append(ParserResRobot::getName());
     result.append(ParserFinlandMatka::getName());
+    result.append(ParserVRREFA::getName());
 
     // Make sure the index is in bounds
     if (currentParserIndex > (result.count() - 1) || currentParserIndex < 0) {

--- a/src/fahrplan_parser_thread.cpp
+++ b/src/fahrplan_parser_thread.cpp
@@ -170,6 +170,9 @@ void FahrplanParserThread::run()
         case 15:
             m_parser = new ParserFinlandMatka();
             break;
+        case 16:
+            m_parser = new ParserVRREFA();
+            break;
     }
 
     m_name = m_parser->name();

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -40,6 +40,7 @@
 #include "parser/parser_salzburg_efa.h"
 #include "parser/parser_resrobot.h"
 #include "parser/parser_finland_matka.h"
+#include "parser/parser_vrr_efa.h"
 
 class FahrplanParserThread : public QThread
 {

--- a/src/parser/parser_vrr_efa.cpp
+++ b/src/parser/parser_vrr_efa.cpp
@@ -1,0 +1,43 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "parser_vrr_efa.h"
+
+#include <QBuffer>
+#include <QDomDocument>
+#include <QFile>
+#include <QNetworkReply>
+
+ParserVRREFA::ParserVRREFA(QObject *parent) :
+    ParserEFA(parent)
+{
+    baseRestUrl = "http://efa.vrr.de/standard/";
+    acceptEncoding = "gzip";
+}
+
+QStringList ParserVRREFA::getTrainRestrictions()
+{
+    QStringList result;
+    result.append(tr("All"));
+    result.append(tr("S-Bahn"));
+    result.append(tr("U-Bahn"));
+    result.append(tr("Tram"));
+    result.append(tr("Bus"));
+    return result;
+}

--- a/src/parser/parser_vrr_efa.h
+++ b/src/parser/parser_vrr_efa.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#ifndef PARSER_VRR_EFA_H
+#define PARSER_VRR_EFA_H
+
+#include <QObject>
+#include "parser_efa.h"
+
+class ParserVRREFA : public ParserEFA
+{
+    Q_OBJECT
+public:
+    explicit ParserVRREFA(QObject *parent = 0);
+    static QString getName() { return QString("%1, %2 (vrr.de)").arg(tr("Germany"), tr("Rhine Ruhr")); }
+    virtual QString name() { return getName(); }
+    virtual QString shortName() { return "vrr.de"; }
+
+protected:
+    QStringList getTrainRestrictions();
+
+};
+
+
+#endif // PARSER_VRR_EFA_H

--- a/translations/fahrplan_de.ts
+++ b/translations/fahrplan_de.ts
@@ -1468,6 +1468,44 @@ Von der Fahrplan-App hinzugefügt. Bitte überprüfen Sie diese Informationen vo
     </message>
 </context>
 <context>
+    <name>ParserVRREFA</name>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.cpp" line="38"/>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+    <location filename="../src/parser/parser_vrr_efa.cpp" line="38"/>
+        <source>S-Bahn</source>
+        <translation>S-Bahn</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.cpp" line="39"/>
+        <source>U-Bahn</source>
+        <translation>U-Bahn</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.cpp" line="40"/>
+        <source>Tram</source>
+        <translation>Straßenbahn</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.cpp" line="41"/>
+        <source>Bus</source>
+        <translation>Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.h" line="31"/>
+        <source>Germany</source>
+        <translation>Deutschland</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_vrr_efa.h" line="31"/>
+        <source>Rhine Ruhr</source>
+        <translation>Rhein Ruhr</translation>
+    </message>
+</context>
+<context>
     <name>ParserNinetwo</name>
     <message>
         <location filename="../src/parser/parser_ninetwo.cpp" line="192"/>


### PR DESCRIPTION
Reuses the existing EFA parser class.