### PR TITLE
Station covers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/bb10-qt-components"]
 	path = 3rdparty/bb10-qt-components
 	url = https://github.com/leppa/bb10-qt-components.git
+[submodule "3rdparty/QuickDownload"]
+	path = 3rdparty/QuickDownload
+	url = https://github.com/larpon/QuickDownload

--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -345,6 +345,8 @@ exists($$[QT_INSTALL_PREFIX]/include/sailfishapp/sailfishapp.h): {
         INCLUDEPATH += /usr/include/mkcal-qt5 /usr/include/kcalcoren-qt5
     }
 
+    include("3rdparty/QuickDownload/quickdownload.pri")
+
     RESOURCES += sailfishos_res.qrc
 
     SAILFISH_GUI_FILES += \

--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -346,11 +346,11 @@ exists($$[QT_INSTALL_PREFIX]/include/sailfishapp/sailfishapp.h): {
     }
 
     # needed for downloading station covers
-    MAPTILER_KEY = $$(FAHRPLAN2_MAPTILER_KEY)  # environment
-    equals(MAPTILER_KEY, "") {
-        message("No maptiler key found in FAHRPLAN2_MAPTILER_KEY. Station covers disabled.")
+    MAPS_KEY = $$(FAHRPLAN2_MAPS_KEY)  # environment
+    equals(MAPS_KEY, "") {
+        message("No maps key found in FAHRPLAN2_MAPS_KEY. Station covers disabled.")
     }
-    DEFINES += MAPTILER_KEY=\\\"$$MAPTILER_KEY\\\"
+    DEFINES += MAPS_KEY=\\\"$$MAPS_KEY\\\"
     include("3rdparty/QuickDownload/quickdownload.pri")
 
     RESOURCES += sailfishos_res.qrc

--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -345,6 +345,12 @@ exists($$[QT_INSTALL_PREFIX]/include/sailfishapp/sailfishapp.h): {
         INCLUDEPATH += /usr/include/mkcal-qt5 /usr/include/kcalcoren-qt5
     }
 
+    # needed for downloading station covers
+    MAPTILER_KEY = $$(FAHRPLAN2_MAPTILER_KEY)  # environment
+    equals(MAPTILER_KEY, "") {
+        message("No maptiler key found in FAHRPLAN2_MAPTILER_KEY. Station covers disabled.")
+    }
+    DEFINES += MAPTILER_KEY=\\\"$$MAPTILER_KEY\\\"
     include("3rdparty/QuickDownload/quickdownload.pri")
 
     RESOURCES += sailfishos_res.qrc

--- a/src/gui/sailfishos/delegates/StationTileDelegate.qml
+++ b/src/gui/sailfishos/delegates/StationTileDelegate.qml
@@ -6,6 +6,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Fahrplan 1.0
+import com.blackgrain.qml.quickdownload 1.0
 
 import "../components"
 
@@ -138,5 +139,70 @@ TileBase {
 
     Behavior on opacity {
         FadeAnimator {}
+    }
+
+    Download {
+        id: coverDownload
+
+        running: false
+        followRedirects: true
+        overwrite: false
+
+        onError: {
+            if (errorCode == Download.ErrorDestination &&
+                    /^Overwriting not allowed/.test(errorString)) {
+                console.log("using cached station cover:", ident, latitude, longitude)
+                backgroundImage = destination
+            } else {
+                console.error("failed to fetch station cover:", ident, latitude, longitude, errorString)
+            }
+        }
+        onFinished: {
+            console.log("station cover downloaded:", ident, latitude, longitude)
+            backgroundImage = destination
+        }
+
+        Component.onCompleted: {
+            // @disable-check M126
+            if (MAPTILER_KEY == "") {
+                return
+            }
+
+            if (latitude < -90 || latitude > 90 ||
+                longitude < -180 || longitude > 180 ||
+                (latitude == 0.0 && longitude == 0.0)
+            ) {
+                return
+            }
+
+            var zoom_level = 18  // looks best
+            var tile_url = 'https://api.maptiler.com/tiles/satellite-v2/%1/%2/%3.jpg?key=%4'
+
+            // SPDX-SnippetBegin
+            // SPDX-SnippetCopyrightText: OSM Wiki Contributors
+            // SPDX-License-Identifier: CC-BY-SA-2.0
+            // Source: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+            function lon2tile(lon, zoom) {
+                return (Math.floor((lon+180)/360*Math.pow(2,zoom)));
+            }
+            function lat2tile(lat, zoom) {
+                return (Math.floor((1-Math.log(Math.tan(lat*Math.PI/180)
+                                               + 1/Math.cos(lat*Math.PI/180))/Math.PI)/2
+                                   * Math.pow(2,zoom)));
+            }
+            // SPDX-SnippetEnd
+
+            var xtile = lon2tile(longitude, zoom_level)
+            var ytile = lat2tile(latitude, zoom_level)
+            var final_url = tile_url.arg(zoom_level).arg(xtile).arg(ytile).arg(MAPTILER_KEY)
+
+            destination = "%1/%2x%3x%4"
+                .arg(StandardPaths.cache)
+                .arg(zoom_level)
+                .arg(xtile)
+                .arg(ytile)
+            url = final_url
+            running = true
+        }
     }
 }

--- a/src/gui/sailfishos/delegates/StationTileDelegate.qml
+++ b/src/gui/sailfishos/delegates/StationTileDelegate.qml
@@ -164,7 +164,9 @@ TileBase {
 
         Component.onCompleted: {
             // @disable-check M126
-            if (MAPTILER_KEY == "") {
+            if (MAPS_KEY == "") {
+                // Station covers are disabled if we don't have an API key for
+                // downloading map tiles.
                 return
             }
 
@@ -194,7 +196,7 @@ TileBase {
 
             var xtile = lon2tile(longitude, zoom_level)
             var ytile = lat2tile(latitude, zoom_level)
-            var final_url = tile_url.arg(zoom_level).arg(xtile).arg(ytile).arg(MAPTILER_KEY)
+            var final_url = tile_url.arg(zoom_level).arg(xtile).arg(ytile).arg(MAPS_KEY)
 
             destination = "%1/%2x%3x%4"
                 .arg(StandardPaths.cache)

--- a/src/gui/sailfishos/pages/AboutPage.qml
+++ b/src/gui/sailfishos/pages/AboutPage.qml
@@ -171,6 +171,25 @@ Page {
                     }
 
                     Label {
+                        text: qsTr("Station background images")
+                        font.bold: true
+                    }
+
+                    Label {
+                        wrapMode: Text.WordWrap
+                        width: parent.width
+                        textFormat: Text.StyledText
+                        onLinkActivated : Qt.openUrlExternally(link)
+                        text: "<a href='https://www.maptiler.com/copyright/'>© MapTiler</a> " +
+                              "<a href='https://www.openstreetmap.org/copyright'>© OpenStreetMap contributors</a>"
+                    }
+
+                    Label {
+                        /* spacer */
+                        text: " "
+                    }
+
+                    Label {
                         text: qsTr("License")
                         font.bold: true
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,8 @@ int main(int argc, char *argv[])
 
         #if defined(BUILD_FOR_SAILFISHOS)
             QQuickView *view = SailfishApp::createView();
+
+            view->rootContext()->setContextProperty("MAPTILER_KEY", QStringLiteral(MAPTILER_KEY));
         #elif defined(HAVE_DECLARATIVE_CACHE)
             QDeclarativeView* view = MDeclarativeCache::qDeclarativeView();
         #elif defined(BUILD_FOR_QT5)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
         #if defined(BUILD_FOR_SAILFISHOS)
             QQuickView *view = SailfishApp::createView();
 
-            view->rootContext()->setContextProperty("MAPTILER_KEY", QStringLiteral(MAPTILER_KEY));
+            view->rootContext()->setContextProperty("MAPS_KEY", QStringLiteral(MAPS_KEY));
         #elif defined(HAVE_DECLARATIVE_CACHE)
             QDeclarativeView* view = MDeclarativeCache::qDeclarativeView();
         #elif defined(BUILD_FOR_QT5)


### PR DESCRIPTION
This must be applied *after* #44  *and* #45 have been merged. Or rather, this includes both #44 and #45.

This adds support for downloading satellite map tiles as station cover images in the favorites view. It's already visible in the screenshot in #45 .

I put this into a separate PR because this will need a Maptiler API key. Nothing breaks without the API key, but station covers won't be downloaded. Instead, each station has shows an icon based on its type or a generic fallback icon (that's already in #45 ).


New changes are only in the last 3 commits, starting with 3beececfead430577066270787d55be83ccec97d. Commits 1ac0ccbc43898b91cd40c237485f88217077272f to 8ec6ceb1946a1ee49de049ba0acc4757b7225470 are #44 . Commits 0e5c27c68c12091c346cc7aa660d02654c59e3bb to af50feeeba2426fef269633777e50f80bf6b0bae are #45 .


---

I worked on this and the other PRs over the last couple of weeks and had all changes in one branch. I tried to split it into usable reviewable chunks but my git rebase skills aren't good enough, I mainly just messed up the commits...