### PR TITLE
Add TrentinoTrasporti

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -134,7 +134,8 @@ HEADERS += \
     src/parser/parser_xmlrejseplanendk.h \
     src/parser/parser_xmloebbat.h \
     src/parser/parser_xmlvasttrafikse.h \
-    src/parser/parser_search_ch.h 
+    src/parser/parser_search_ch.h \
+    src/parser/parser_trentino.h
 
 SOURCES += src/main.cpp \
     src/fahrplan.cpp \
@@ -169,7 +170,8 @@ SOURCES += src/main.cpp \
     src/parser/parser_xmlrejseplanendk.cpp \
     src/parser/parser_xmloebbat.cpp \
     src/parser/parser_xmlvasttrafikse.cpp \
-    src/parser/parser_search_ch.cpp
+    src/parser/parser_search_ch.cpp \
+    src/parser/parser_trentino.cpp
 
 
 LIBS += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.cpp

--- a/src/fahrplan_backend_manager.cpp
+++ b/src/fahrplan_backend_manager.cpp
@@ -44,6 +44,7 @@ QStringList FahrplanBackendManager::getParserList()
     result.append(ParserFinlandMatka::getName());
     result.append(ParserVRREFA::getName());
     result.append(ParserSearchCH::getName());
+    result.append(ParserTrentinoTrasporti::getName());
 
     // Make sure the index is in bounds
     if (currentParserIndex > (result.count() - 1) || currentParserIndex < 0) {

--- a/src/fahrplan_parser_thread.cpp
+++ b/src/fahrplan_parser_thread.cpp
@@ -169,6 +169,9 @@ void FahrplanParserThread::run()
         case 14:
             m_parser = new ParserSearchCH();
             break;
+        case 15:
+            m_parser = new ParserTrentinoTrasporti();
+            break;
     }
 
     m_name = m_parser->name();

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -40,6 +40,7 @@
 #include "parser/parser_finland_matka.h"
 #include "parser/parser_vrr_efa.h"
 #include "parser/parser_search_ch.h"
+#include "parser/parser_trentino.h"
 
 class FahrplanParserThread : public QThread
 {

--- a/src/parser/parser_trentino.cpp
+++ b/src/parser/parser_trentino.cpp
@@ -1,0 +1,656 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <https://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include <QUrl>
+#include <QUrlQuery>
+#include <QTimeZone>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QLocale>
+#include <QRegExp>
+#include <QNetworkRequest>
+#include <QTimer>
+
+#include "parser_trentino.h"
+
+// Taken from Muoversi in Trentino Android app
+static const QString BASE_URL = "https://app-tpl.tndigit.it/gtlservice";
+static const QString AUTH_USER = "mittmobile";
+static const QString AUTH_PASS = "ecGsp.RHB3";
+
+ParserTrentinoTrasporti::ParserTrentinoTrasporti(QObject *parent)
+    : ParserAbstract(parent), m_stopsLoaded(false), m_routesLoaded(false)
+{
+}
+
+bool ParserTrentinoTrasporti::supportsGps()
+{
+    return true;
+}
+
+bool ParserTrentinoTrasporti::supportsVia()
+{
+    return false;
+}
+
+bool ParserTrentinoTrasporti::supportsTimeTable()
+{
+    return true;
+}
+
+QStringList ParserTrentinoTrasporti::getTrainRestrictions()
+{
+    QStringList result;
+    result.append(tr("All"));
+    result.append(tr("Bus"));
+    result.append(tr("Train"));
+    result.append(tr("Cableway"));
+    return result;
+}
+
+void ParserTrentinoTrasporti::sendRequest(QUrl url)
+{
+    QByteArray auth = (QString("%1:%2").arg(AUTH_USER, AUTH_PASS)).toUtf8().toBase64();
+    QList<QPair<QByteArray, QByteArray>> headers;
+    headers.append(QPair<QByteArray, QByteArray>("Authorization", "Basic " + auth));
+    headers.append(QPair<QByteArray, QByteArray>("X-Requested-With", "it.tndigit.mit"));
+    headers.append(QPair<QByteArray, QByteArray>("Content-Type", "application/json"));
+
+    qDebug() << "Sending request to" << url.toString();
+    sendHttpRequest(url, NULL, headers);
+}
+
+QVariantList ParserTrentinoTrasporti::parseJsonList(const QByteArray &json) const
+{
+    return QJsonDocument::fromJson(json).array().toVariantList();
+}
+
+void ParserTrentinoTrasporti::parseStationRow(StationsList& results, const QVariantMap& props)
+{
+    Station s;
+    s.id = props.value("stopId");
+    s.name = props.value("stopName").toString();
+    s.latitude = props.value("stopLat").toReal();
+    s.longitude = props.value("stopLon").toReal();
+
+    QString town = props.value("town").toString();
+    if (!town.isEmpty()) {
+        s.miscInfo = town;
+    }
+
+    const QVariantList routes = props.value("routes").toList();
+    bool hasTrain = false;
+    bool hasCableway = false;
+    Q_FOREACH (const QVariant& r, routes) {
+        int rt = r.toMap().value("routeType").toInt();
+        if (rt == 2) {
+            hasTrain = true;
+        } else if (rt == 5) {
+            hasCableway = true;
+        }
+    }
+
+    if (hasTrain) {
+        s.type = "train";
+    } else if (hasCableway) {
+        s.type = "cablecar";
+    } else {
+        s.type = "bus";
+    }
+
+    m_stopsById[s.id.toInt()] = props;
+
+    results.append(s);
+}
+
+void ParserTrentinoTrasporti::findStationsByName(const QString &stationName)
+{
+    if (stationName.length() < 2) {
+        return;
+    }
+
+    if (currentRequestState != FahrplanNS::noneRequest) {
+        return;
+    }
+
+    m_lastSearchTerm = stationName;
+
+    if (m_stopsLoaded) {
+        StationsList results;
+        Q_FOREACH (const Station& s, m_allStops) {
+            if (s.name.contains(stationName, Qt::CaseInsensitive)) {
+                results.append(s);
+            }
+        }
+        emit stationsResult(results);
+        return;
+    }
+
+    currentRequestState = FahrplanNS::stationsByNameRequest;
+
+    QUrl url(BASE_URL + "/stops");
+
+    sendRequest(url);
+}
+
+void ParserTrentinoTrasporti::findStationsByCoordinates(qreal longitude, qreal latitude)
+{
+    if (currentRequestState != FahrplanNS::noneRequest) {
+        return;
+    }
+
+    m_lastSearchTerm = QString::number(latitude) + "," + QString::number(longitude);
+
+    if (m_stopsLoaded) {
+        QStringList coords = m_lastSearchTerm.split(",");
+        qreal refLat = coords.value(0).toDouble();
+        qreal refLon = coords.value(1).toDouble();
+
+        QMultiMap<qreal, Station> sorted;
+        Q_FOREACH (const Station& s, m_allStops) {
+            qreal dist = (refLat - s.latitude) * (refLat - s.latitude)
+                       + (refLon - s.longitude) * (refLon - s.longitude);
+            sorted.insert(dist, s);
+        }
+
+        StationsList results;
+        Q_FOREACH (const Station& s, sorted.values()) {
+            results.append(s);
+            if (results.size() >= 50) {
+                break;
+            }
+        }
+        emit stationsResult(results);
+        return;
+    }
+
+    currentRequestState = FahrplanNS::stationsByCoordinatesRequest;
+
+    QUrl url(BASE_URL + "/stops");
+
+    sendRequest(url);
+}
+
+void ParserTrentinoTrasporti::parseStationsByName(QNetworkReply *networkReply)
+{
+    QByteArray allData(networkReply->readAll());
+
+    QVariantList stations = parseJsonList(allData);
+    if (stations.isEmpty()) {
+        qDebug() << "Invalid reply:" << allData;
+        emit errorOccured(tr("Cannot parse reply from the server"));
+        return;
+    }
+
+    if (!m_stopsLoaded) {
+        m_allStops.clear();
+        Q_FOREACH (const QVariant& featureData, stations) {
+            parseStationRow(m_allStops, featureData.toMap());
+        }
+        m_stopsLoaded = true;
+    }
+
+    StationsList results;
+    Q_FOREACH (const Station& s, m_allStops) {
+        if (s.name.contains(m_lastSearchTerm, Qt::CaseInsensitive)) {
+            results.append(s);
+        }
+    }
+
+    emit stationsResult(results);
+}
+
+void ParserTrentinoTrasporti::parseStationsByCoordinates(QNetworkReply *networkReply)
+{
+    QByteArray allData(networkReply->readAll());
+
+    QVariantList stations = parseJsonList(allData);
+    if (stations.isEmpty()) {
+        qDebug() << "Invalid reply:" << allData;
+        emit errorOccured(tr("Cannot parse reply from the server"));
+        return;
+    }
+
+    if (!m_stopsLoaded) {
+        m_allStops.clear();
+        Q_FOREACH (const QVariant& featureData, stations) {
+            parseStationRow(m_allStops, featureData.toMap());
+        }
+        m_stopsLoaded = true;
+    }
+
+    QStringList coords = m_lastSearchTerm.split(",");
+    qreal refLat = coords.value(0).toDouble();
+    qreal refLon = coords.value(1).toDouble();
+
+    QMultiMap<qreal, Station> sorted;
+    Q_FOREACH (const Station& s, m_allStops) {
+        qreal dist = (refLat - s.latitude) * (refLat - s.latitude)
+                   + (refLon - s.longitude) * (refLon - s.longitude);
+        sorted.insert(dist, s);
+    }
+
+    StationsList results;
+    Q_FOREACH (const Station& s, sorted.values()) {
+        results.append(s);
+        if (results.size() >= 50) {
+            break;
+        }
+    }
+
+    emit stationsResult(results);
+}
+
+void ParserTrentinoTrasporti::fetchRoutes()
+{
+    QUrl url(BASE_URL + "/routes");
+    QNetworkRequest request(url);
+
+    QByteArray auth = (QString("%1:%2").arg(AUTH_USER, AUTH_PASS)).toUtf8().toBase64();
+    request.setRawHeader("Authorization", "Basic " + auth);
+    request.setRawHeader("X-Requested-With", "it.tndigit.mit");
+    request.setRawHeader("User-Agent", userAgent.toLatin1());
+    request.setRawHeader("Content-Type", "application/json");
+
+    qDebug() << "Fetching routes from" << url.toString();
+    QNetworkReply *reply = NetworkManager->get(request);
+    connect(reply, SIGNAL(finished()), this, SLOT(onRoutesReplyFinished()));
+}
+
+void ParserTrentinoTrasporti::onRoutesReplyFinished()
+{
+    QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply) {
+        return;
+    }
+
+    QByteArray allData = reply->readAll();
+    QVariantList routes = parseJsonList(allData);
+
+    Q_FOREACH (const QVariant& v, routes) {
+        QVariantMap r = v.toMap();
+        int routeId = r.value("routeId").toInt();
+        QString shortName = r.value("routeShortName").toString();
+        m_routeNames[routeId] = shortName;
+    }
+
+    m_routesLoaded = true;
+    reply->deleteLater();
+
+    QTimer::singleShot(0, this, SLOT(doGetTimeTableForStation()));
+}
+
+void ParserTrentinoTrasporti::getTimeTableForStation(const Station &currentStation,
+    const Station &directionStation, const QDateTime &dateTime, Mode mode,
+    int restrictions)
+{
+    Q_UNUSED(directionStation);
+
+    if (currentRequestState != FahrplanNS::noneRequest) {
+        return;
+    }
+
+    m_timetableStation = currentStation;
+    m_timetableDirection = directionStation;
+    m_timetableDateTime = dateTime;
+    m_timetableMode = mode;
+    m_timetableRestrictions = restrictions;
+
+    if (!m_routesLoaded) {
+        fetchRoutes();
+        return;
+    }
+
+    doGetTimeTableForStation();
+}
+
+void ParserTrentinoTrasporti::doGetTimeTableForStation()
+{
+    currentRequestState = FahrplanNS::getTimeTableForStationRequest;
+
+    QVariantMap stop = m_stopsById.value(m_timetableStation.id.toInt());
+    QString stopType = stop.value("type", "U").toString();
+
+    QUrl url(BASE_URL + "/trips_new");
+    QUrlQuery query;
+    query.addQueryItem("stopId", m_timetableStation.id.toString());
+    query.addQueryItem("type", stopType);
+    query.addQueryItem("limit", "20");
+    query.addQueryItem("refDateTime", m_timetableDateTime.toUTC().toString(Qt::ISODate));
+    url.setQuery(query);
+
+    sendRequest(url);
+}
+
+void ParserTrentinoTrasporti::parseTimeTable(QNetworkReply *networkReply)
+{
+    TimetableEntriesList timetable;
+    QByteArray allData(networkReply->readAll());
+
+    QVariantList trips = parseJsonList(allData);
+    if (trips.isEmpty()) {
+        qDebug() << "Invalid reply or empty timetable:" << allData;
+        emit errorOccured(tr("No departures found for this station."));
+        return;
+    }
+
+    int restriction = m_timetableRestrictions;
+
+    Q_FOREACH (const QVariant& v, trips) {
+        QVariantMap trip = v.toMap();
+
+        int routeType = 0;
+        int routeId = trip.value("routeId").toInt();
+        QString routeName = m_routeNames.value(routeId, "");
+
+        QVariantMap stop = m_stopsById.value(m_timetableStation.id.toInt());
+        const QVariantList routes = stop.value("routes").toList();
+        Q_FOREACH (const QVariant& r, routes) {
+            if (r.toMap().value("routeId").toInt() == routeId) {
+                routeType = r.toMap().value("routeType").toInt();
+                break;
+            }
+        }
+
+        // Apply train restrictions
+        if (restriction == 1 && routeType != 3) { // Bus only
+            continue;
+        }
+        if (restriction == 2 && routeType != 2) { // Train only
+            continue;
+        }
+        if (restriction == 3 && routeType != 5) { // Cableway only
+            continue;
+        }
+
+        TimetableEntry entry;
+        entry.currentStation = m_timetableStation.name;
+        entry.destinationStation = trip.value("tripHeadsign").toString();
+
+        if (!routeName.isEmpty()) {
+            entry.trainType = routeName;
+        } else {
+            entry.trainType = entry.destinationStation;
+        }
+
+        QString effectiveTime = trip.value("oraArrivoEffettivaAFermataSelezionata").toString();
+        QString scheduledTime = trip.value("oraArrivoProgrammataAFermataSelezionata").toString();
+
+        QDateTime dt;
+        if (!effectiveTime.isEmpty()) {
+            dt = QDateTime::fromString(effectiveTime, Qt::ISODate);
+        }
+        if (!dt.isValid() && !scheduledTime.isEmpty()) {
+            dt = QDateTime::fromString(scheduledTime, Qt::ISODate);
+        }
+        if (dt.isValid()) {
+            entry.time = dt.toLocalTime().time();
+        }
+
+        QVariant delay = trip.value("delay");
+        if (!delay.isNull() && delay.toDouble() > 0.0) {
+            entry.miscInfo = tr("Delay: %1'").arg(QString::number((int)delay.toDouble()));
+        }
+
+        timetable.append(entry);
+    }
+
+    emit timetableResult(timetable);
+}
+
+QDateTime ParserTrentinoTrasporti::jodaTimeToQDateTime(const QVariantMap &dt) const
+{
+    int year = dt.value("year").toInt();
+    int month = dt.value("monthOfYear").toInt();
+    int day = dt.value("dayOfMonth").toInt();
+    int hour = dt.value("hourOfDay").toInt();
+    int minute = dt.value("minuteOfHour").toInt();
+    QTimeZone tz("Europe/Rome");
+    return QDateTime(QDate(year, month, day), QTime(hour, minute), tz).toLocalTime();
+}
+
+void ParserTrentinoTrasporti::searchJourney(const Station &departureStation,
+    const Station &viaStation, const Station &arrivalStation,
+    const QDateTime &dateTime, Mode mode, int restrictions)
+{
+    Q_UNUSED(viaStation);
+
+    if (currentRequestState != FahrplanNS::noneRequest) {
+        return;
+    }
+
+    currentRequestState = FahrplanNS::searchJourneyRequest;
+
+    m_journeyFrom = departureStation;
+    m_journeyTo = arrivalStation;
+    m_journeyWhen = dateTime;
+    m_journeyMode = mode;
+    m_journeyRestrictions = restrictions;
+
+    QUrl url(BASE_URL + "/direction");
+    QUrlQuery query;
+    QString fromStr = QString::number(departureStation.latitude) + ","
+                    + QString::number(departureStation.longitude);
+    QString toStr = QString::number(arrivalStation.latitude) + ","
+                  + QString::number(arrivalStation.longitude);
+    query.addQueryItem("from", fromStr);
+    query.addQueryItem("to", toStr);
+    query.addQueryItem("lang", "it");
+    query.addQueryItem("refDateTime", dateTime.toUTC().toString(Qt::ISODate));
+    url.setQuery(query);
+
+    sendRequest(url);
+}
+
+void ParserTrentinoTrasporti::parseSearchJourney(QNetworkReply *networkReply)
+{
+    QByteArray allData(networkReply->readAll());
+    QVariantMap doc = parseJson(allData);
+
+    if (doc.isEmpty()) {
+        qDebug() << "Invalid reply:" << allData;
+        emit errorOccured(tr("Cannot parse reply from the server"));
+        return;
+    }
+
+    JourneyResultList *result = new JourneyResultList();
+    result->setDepartureStation(m_journeyFrom.name);
+    result->setArrivalStation(m_journeyTo.name);
+    if (m_journeyMode == Arrival) {
+        result->setTimeInfo(tr("Arrivals %1").arg(
+            m_journeyWhen.toString(tr("ddd MMM d, HH:mm"))));
+    } else {
+        result->setTimeInfo(tr("Departures %1").arg(
+            m_journeyWhen.toString(tr("ddd MMM d, HH:mm"))));
+    }
+
+    while (!m_details.isEmpty()) {
+        delete m_details.takeFirst();
+    }
+
+    QVariantList routes = doc.value("routes").toList();
+    int connId = 0;
+
+    Q_FOREACH (const QVariant& routeVar, routes) {
+        QVariantMap route = routeVar.toMap();
+        QVariantList legs = route.value("legs").toList();
+        if (legs.isEmpty()) continue;
+
+        QVariantList steps = legs.first().toMap().value("steps").toList();
+        if (steps.isEmpty()) continue;
+
+        // Collect transit segments
+        struct TransitStep {
+            QString departureStation;
+            QDateTime departureTime;
+            QString arrivalStation;
+            QDateTime arrivalTime;
+            QString lineShortName;
+            QString headsign;
+            int numStops;
+            double delay;
+            QString vehicleType;
+        };
+        QList<TransitStep> transitSteps;
+
+        Q_FOREACH (const QVariant& stepVar, steps) {
+            QVariantMap step = stepVar.toMap();
+            QString travelMode = step.value("travelMode").toString();
+            if (travelMode != "TRANSIT") continue;
+
+            QVariantMap td = step.value("transitDetails").toMap();
+            TransitStep ts;
+            ts.departureStation = td.value("departureStop").toMap().value("name").toString();
+            ts.arrivalStation = td.value("arrivalStop").toMap().value("name").toString();
+            ts.departureTime = jodaTimeToQDateTime(td.value("departureTime").toMap());
+            ts.arrivalTime = jodaTimeToQDateTime(td.value("arrivalTime").toMap());
+            ts.lineShortName = td.value("line").toMap().value("shortName").toString();
+            ts.headsign = td.value("headsign").toString();
+            ts.numStops = td.value("numStops").toInt();
+            ts.delay = td.value("delay").toDouble();
+            ts.vehicleType = td.value("line").toMap().value("vehicle").toMap()
+                .value("type").toString();
+            transitSteps.append(ts);
+        }
+
+        if (transitSteps.isEmpty()) continue;
+
+        // Apply train restrictions
+        if (m_journeyRestrictions > 0) {
+            bool skip = false;
+            Q_FOREACH (const TransitStep& ts, transitSteps) {
+                QString vt = ts.vehicleType;
+                if (m_journeyRestrictions == 1 && (vt == "TRAIN" || vt == "CABLE_CAR")) {
+                    skip = true; break;
+                }
+                if (m_journeyRestrictions == 2 && (vt == "BUS" || vt == "CABLE_CAR")) {
+                    skip = true; break;
+                }
+                if (m_journeyRestrictions == 3 && (vt == "BUS" || vt == "TRAIN")) {
+                    skip = true; break;
+                }
+            }
+            if (skip) continue;
+        }
+
+        // Build JourneyResultItem (summary)
+        JourneyResultItem *item = new JourneyResultItem();
+        item->setId(QString::number(connId));
+
+        QDateTime firstDep = transitSteps.first().departureTime;
+        QDateTime lastArr = transitSteps.last().arrivalTime;
+        item->setDate(firstDep.date());
+        item->setDepartureTime(firstDep.toLocalTime().toString("HH:mm"));
+        item->setArrivalTime(lastArr.toLocalTime().toString("HH:mm"));
+
+        int totalSecs = firstDep.secsTo(lastArr);
+        item->setDuration(QString("%1:%2").arg(totalSecs / 3600)
+            .arg((totalSecs % 3600) / 60, 2, 10, QChar('0')));
+
+        QStringList lineNames;
+        Q_FOREACH (const TransitStep& ts, transitSteps) {
+            if (!ts.lineShortName.isEmpty()) {
+                lineNames.append(ts.lineShortName);
+            }
+        }
+        item->setTrainType(lineNames.join(" "));
+
+        int transfers = transitSteps.size() - 1;
+        if (transfers > 0) {
+            item->setTransfers(QString::number(transfers));
+        }
+
+        // Check for delays
+        Q_FOREACH (const TransitStep& ts, transitSteps) {
+            if (ts.delay > 0.0) {
+                item->setMiscInfo(tr("Delay: %1'").arg(QString::number((int)ts.delay)));
+                break;
+            }
+        }
+
+        result->appendItem(item);
+
+        // Build JourneyDetailResultList (segments)
+        JourneyDetailResultList *details = new JourneyDetailResultList();
+        details->setId(QString::number(connId));
+        details->setDepartureStation(m_journeyFrom.name);
+        details->setArrivalStation(m_journeyTo.name);
+        details->setDepartureDateTime(firstDep);
+        details->setArrivalDateTime(lastArr);
+        details->setDuration(item->duration());
+
+        Q_FOREACH (const TransitStep& ts, transitSteps) {
+            JourneyDetailResultItem *segment = new JourneyDetailResultItem();
+            segment->setDepartureStation(ts.departureStation);
+            segment->setDepartureDateTime(ts.departureTime);
+            segment->setArrivalStation(ts.arrivalStation);
+            segment->setArrivalDateTime(ts.arrivalTime);
+            segment->setTrain(ts.lineShortName);
+            segment->setDirection(ts.headsign);
+
+            if (ts.delay > 0.0) {
+                segment->setInfo(tr("Delay: %1'").arg(QString::number((int)ts.delay)));
+            }
+
+            details->appendItem(segment);
+        }
+
+        m_details.append(details);
+        connId++;
+    }
+
+    emit journeyResult(result);
+}
+
+void ParserTrentinoTrasporti::getJourneyDetails(const QString &id)
+{
+    int i = id.toInt();
+    if (m_details.length() > i) {
+        emit journeyDetailsResult(m_details[i]);
+    } else {
+        emit errorOccured(tr("No journey details found."));
+    }
+}
+
+void ParserTrentinoTrasporti::searchJourneyLater()
+{
+    QDateTime nextQueryTime;
+    if (m_details.length() > 0) {
+        JourneyDetailResultList *lastDetail = m_details.last();
+        nextQueryTime = lastDetail->departureDateTime().addSecs(60);
+    } else {
+        nextQueryTime = m_journeyWhen.addSecs(3600);
+    }
+    searchJourney(m_journeyFrom, Station(false), m_journeyTo,
+                  nextQueryTime, Departure, m_journeyRestrictions);
+}
+
+void ParserTrentinoTrasporti::searchJourneyEarlier()
+{
+    QDateTime nextQueryTime;
+    if (m_details.length() > 0) {
+        JourneyDetailResultList *firstDetail = m_details.first();
+        nextQueryTime = firstDetail->arrivalDateTime().addSecs(-60);
+    } else {
+        nextQueryTime = m_journeyWhen.addSecs(-3600);
+    }
+    searchJourney(m_journeyFrom, Station(false), m_journeyTo,
+                  nextQueryTime, Arrival, m_journeyRestrictions);
+}

--- a/src/parser/parser_trentino.h
+++ b/src/parser/parser_trentino.h
@@ -1,0 +1,78 @@
+#ifndef PARSER_TRENTINO_H
+#define PARSER_TRENTINO_H
+
+#include <QMap>
+#include <QNetworkReply>
+
+#include "parser_abstract.h"
+
+class ParserTrentinoTrasporti : public ParserAbstract {
+  Q_OBJECT
+public:
+  explicit ParserTrentinoTrasporti(QObject *parent = 0);
+  static QString getName() {
+    return QString("%1 (Trentino Trasporti)").arg(tr("Italy"));
+  }
+  virtual QString name() { return getName(); }
+  virtual QString shortName() { return "trentinotrasporti.it"; }
+
+public slots:
+  virtual bool supportsGps();
+  virtual bool supportsVia();
+  virtual bool supportsTimeTable();
+  virtual void findStationsByName(const QString &stationName);
+  virtual void findStationsByCoordinates(qreal longitude, qreal latitude);
+  virtual void getTimeTableForStation(const Station &currentStation,
+                                      const Station &directionStation,
+                                      const QDateTime &dateTime,
+                                      ParserAbstract::Mode mode,
+                                      int trainrestrictions);
+  virtual void searchJourney(const Station &departureStation,
+                             const Station &viaStation,
+                             const Station &arrivalStation,
+                             const QDateTime &dateTime,
+                             ParserAbstract::Mode mode, int trainrestrictions);
+  virtual void getJourneyDetails(const QString &id);
+
+protected:
+  virtual QStringList getTrainRestrictions();
+  virtual void parseStationsByName(QNetworkReply *);
+  virtual void parseStationsByCoordinates(QNetworkReply *);
+  virtual void parseTimeTable(QNetworkReply *);
+  virtual void parseSearchJourney(QNetworkReply *);
+  virtual void searchJourneyLater();
+  virtual void searchJourneyEarlier();
+
+private slots:
+  void onRoutesReplyFinished();
+  void doGetTimeTableForStation();
+
+private:
+  void sendRequest(QUrl url);
+  QVariantList parseJsonList(const QByteArray &json) const;
+  void parseStationRow(StationsList &results, const QVariantMap &props);
+  void fetchRoutes();
+  QDateTime jodaTimeToQDateTime(const QVariantMap &dt) const;
+
+  QMap<int, QString> m_routeNames;
+  QMap<int, QVariantMap> m_stopsById;
+  StationsList m_allStops;
+  bool m_stopsLoaded;
+  QString m_lastSearchTerm;
+
+  Station m_timetableStation;
+  Station m_timetableDirection;
+  QDateTime m_timetableDateTime;
+  ParserAbstract::Mode m_timetableMode;
+  int m_timetableRestrictions;
+  bool m_routesLoaded;
+
+  Station m_journeyFrom;
+  Station m_journeyTo;
+  QDateTime m_journeyWhen;
+  ParserAbstract::Mode m_journeyMode;
+  int m_journeyRestrictions;
+  QList<JourneyDetailResultList *> m_details;
+};
+
+#endif

--- a/translations/fahrplan_ar.ts
+++ b/translations/fahrplan_ar.ts
@@ -2455,6 +2455,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">الكل</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">حافلات</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_ca.ts
+++ b/translations/fahrplan_ca.ts
@@ -2426,6 +2426,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Tot</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Tren</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_de.ts
+++ b/translations/fahrplan_de.ts
@@ -2427,6 +2427,74 @@ Von der Fahrplan-App hinzugefügt. Bitte überprüfen Sie diese Informationen vo
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Alle</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Zug</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished">Seilbahn</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Kann Antwort vom Server nicht verarbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished">Ankünfte %1</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd MMM d, HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished">Abfahrten %1</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished">Verbindungsdetails nicht gefunden.</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_el.ts
+++ b/translations/fahrplan_el.ts
@@ -2427,6 +2427,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Ολα</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Λεωφορείο</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Τρένο</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd MMM d, HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_en.ts
+++ b/translations/fahrplan_en.ts
@@ -2426,6 +2426,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_es.ts
+++ b/translations/fahrplan_es.ts
@@ -2427,6 +2427,74 @@ Añadido por Fahrplan. Por favor, compruebe la información antes de su viaje.</
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Todos</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Autobús</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Tren</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">No se ha podido interpretar la respuesta del servidor</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_fa_IR.ts
+++ b/translations/fahrplan_fa_IR.ts
@@ -2419,6 +2419,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">همه</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">اتوبوس</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">قطار</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">پاسخ سرور را نمی توان تجزیه کرد</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_fr.ts
+++ b/translations/fahrplan_fr.ts
@@ -2427,6 +2427,74 @@ Ajouté par Fahrplan. Veuillez revérifier l&apos;information avant votre dépar
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Train</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Ne peut analyser la réponse du serveur</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">jjj MMM j, HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_hu.ts
+++ b/translations/fahrplan_hu.ts
@@ -2419,6 +2419,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_nb.ts
+++ b/translations/fahrplan_nb.ts
@@ -2426,6 +2426,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Alle</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Buss</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Tog</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Uforståelig svar fra server</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd MMM d, TT:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_nl_NL.ts
+++ b/translations/fahrplan_nl_NL.ts
@@ -2427,6 +2427,74 @@ Toegevoegd door Fahrplan. Noot: controleer de informatie opnieuw vlak voordat u 
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Alles</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Bus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Trein</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Kan antwoord van de server niet parseren</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd MMM d, HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_pl.ts
+++ b/translations/fahrplan_pl.ts
@@ -2434,6 +2434,74 @@ Dodane przez Fahrplan. Prosimy zweryfikować informację przed rozpoczęciem pod
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Wszystkie</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Autobus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_ro_RO.ts
+++ b/translations/fahrplan_ro_RO.ts
@@ -2434,6 +2434,74 @@ Adăugat de Fahrplan. Vă rugăm, reverificați informația înainte de călăto
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Toate</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Autobuz</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Tren</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_ru.ts
+++ b/translations/fahrplan_ru.ts
@@ -2434,6 +2434,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Все</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Автобус</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Поезд</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Не могу разобрать ответ сервера</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_sl_SI.ts
+++ b/translations/fahrplan_sl_SI.ts
@@ -2441,6 +2441,74 @@ Dodala aplikacija Fahrplan. Pred potovanjem prosimo preverite točnost informaci
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Vsi</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Avtobus</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Vlak</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd MMM d, HH:mm</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/fahrplan_sv_SE.ts
+++ b/translations/fahrplan_sv_SE.ts
@@ -1824,6 +1824,57 @@ Tillagt av Fahrplan. Kolla informationen innan resan.</translation>
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Alla</translation>
+    </message>
+    <message>
+        <source>Bus</source>
+        <translation type="unfinished">Buss</translation>
+    </message>
+    <message>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arrivals %1</source>
+        <translation type="unfinished">Ankomster: %1</translation>
+    </message>
+    <message>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished">ddd d MMM, HH:mm</translation>
+    </message>
+    <message>
+        <source>Departures %1</source>
+        <translation type="unfinished">Avgångar: %1</translation>
+    </message>
+    <message>
+        <source>No journey details found.</source>
+        <translation type="unfinished">Inga detaljer hittades för resan.</translation>
+    </message>
+    <message>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <source>All</source>
@@ -2031,8 +2082,6 @@ Tillagt av Fahrplan. Kolla informationen innan resan.</translation>
         <translation>Aktivera stöd för GPS-positionering</translation>
     </message>
     <message>
-        <source> Mapbox key for Station backgrounds</source>
-        <translation> Mapbox-nyckel för stationsbakgrunder</translation>
         <source> Mapbox key, Station backgrounds</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/fahrplan_uk.ts
+++ b/translations/fahrplan_uk.ts
@@ -2434,6 +2434,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished">Усі</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished">Автобус</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished">Потяг</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished">Не можу розібрати відовідь сервера</translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>

--- a/translations/harbour-fahrplan2.ts
+++ b/translations/harbour-fahrplan2.ts
@@ -2419,6 +2419,74 @@ Added by Fahrplan. Please, re-check the information before your journey.</source
     </message>
 </context>
 <context>
+    <name>ParserTrentinoTrasporti</name>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="62"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="63"/>
+        <source>Bus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="64"/>
+        <source>Train</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="65"/>
+        <source>Cableway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="214"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="243"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="505"/>
+        <source>Cannot parse reply from the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="374"/>
+        <source>No departures found for this station.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="433"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="619"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="645"/>
+        <source>Delay: %1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="513"/>
+        <source>Arrivals %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="514"/>
+        <location filename="../src/parser/parser_trentino.cpp" line="517"/>
+        <source>ddd MMM d, HH:mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="516"/>
+        <source>Departures %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.cpp" line="664"/>
+        <source>No journey details found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/parser/parser_trentino.h" line="14"/>
+        <source>Italy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ParserVRREFA</name>
     <message>
         <location filename="../src/parser/parser_vrr_efa.cpp" line="61"/>


### PR DESCRIPTION
This adds support for [TrentinoTrasporti](https://www.trentinotrasporti.it/en/). The API (reversed engineered from [here](https://github.com/matteocontrini/trentino-trasporti-api) and from the official [Muoversi in Trentino](https://play.google.com/store/apps/details?id=it.tndigit.mit) android app) doesn't provide a way to plan trips by arrival time, nor to filter the results by bus/train only.