### PR TITLE
Don't read maps key from build env, it's user-defined now

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -349,11 +349,6 @@ exists($$[QT_INSTALL_PREFIX]/include/sailfishapp/sailfishapp.h): {
     }
 
     # needed for downloading station covers
-    MAPS_KEY = $$(FAHRPLAN2_MAPS_KEY)  # environment
-    equals(MAPS_KEY, "") {
-        message("No maps key found in FAHRPLAN2_MAPS_KEY. Station covers disabled.")
-    }
-    DEFINES += MAPS_KEY=\\\"$$MAPS_KEY\\\"
     include("3rdparty/QuickDownload/quickdownload.pri")
 
     RESOURCES += sailfishos_res.qrc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,8 +185,6 @@ int main(int argc, char *argv[])
 
         #if defined(BUILD_FOR_SAILFISHOS)
             QQuickView *view = SailfishApp::createView();
-
-            view->rootContext()->setContextProperty("MAPS_KEY", QStringLiteral(MAPS_KEY));
         #elif defined(HAVE_DECLARATIVE_CACHE)
             QDeclarativeView* view = MDeclarativeCache::qDeclarativeView();
         #elif defined(BUILD_FOR_QT5)


### PR DESCRIPTION
Fixes whatever [this comment](https://github.com/poetaster/fahrplan/commit/c2a7272145fc6e1c6b6cf9ccaf18ba90185db49d#commitcomment-189763353) by @Thaodan was referring to.

Maptiles/Mapbox keys are read from user settings anyway, so we don't need this build setting anymore.